### PR TITLE
Support Oracle JDBC Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,16 +95,17 @@ variables:
 - `DB_CONN_MAXIDLE` the maximum number of idle connections (default: `20`
   - ignored when app server = `wildfly`)
 - `DB_CONN_MINIDLE` the minimum number of idle connections (default: `5`)
-- `DB_DRIVER` the database driver class name, supported are h2, mysql and
-  postgresql:
+- `DB_DRIVER` the database driver class name, supported are h2, mysql, postgresql and oracle:
   - h2: `DB_DRIVER=org.h2.Driver`
   - mysql: `DB_DRIVER=com.mysql.jdbc.Driver`
   - postgresql: `DB_DRIVER=org.postgresql.Driver`
+  - oracle: `DB_DRIVER=oracle.jdbc.OracleDriver`
 - `DB_URL` the database jdbc url
 - `DB_USERNAME` the database username
 - `DB_PASSWORD` the database password
 - `DB_VALIDATE_ON_BORROW` validate database connections before they are used (default: `false`)
 - `DB_VALIDATION_QUERY` the query to execute to validate database connections (default: `"SELECT 1"`)
+  - oracle: `DB_VALIDATION_QUERY="select 1 from dual"`
 - `DB_PASSWORD_FILE` this supports [Docker Secrets](https://docs.docker.com/engine/swarm/secrets/). 
   Put here the path of the secret, e.g. `/run/secrets/camunda_db_password`. 
   Make sure that `DB_PASSWORD` is not set when using this variable!

--- a/camunda-wildfly.sh
+++ b/camunda-wildfly.sh
@@ -46,6 +46,9 @@ case ${DB_DRIVER} in
   *postgresql* )
     DB_DRIVER=postgresql
   ;;
+  *oracle* )
+    DB_DRIVER=oracle
+  ;;
   * ) echo "Unsupported DB_DRIVER ${DB_DRIVER}"; exit 1;
   ;;
 esac

--- a/download.sh
+++ b/download.sh
@@ -50,12 +50,16 @@ mvn dependency:get -B --global-settings /tmp/settings.xml \
 cambpmdbsettings_pom_file=$(find /m2-repository -name "camunda-database-settings-${ARTIFACT_VERSION}.pom" -print | head -n 1)
 MYSQL_VERSION=$(xmlstarlet sel -t -v //_:version.mysql $cambpmdbsettings_pom_file)
 POSTGRESQL_VERSION=$(xmlstarlet sel -t -v //_:version.postgresql $cambpmdbsettings_pom_file)
+ORACLE_VERSION=19.3.0.0
 
 mvn dependency:copy -B \
     -Dartifact="mysql:mysql-connector-java:${MYSQL_VERSION}:jar" \
     -DoutputDirectory=/tmp/
 mvn dependency:copy -B \
     -Dartifact="org.postgresql:postgresql:${POSTGRESQL_VERSION}:jar" \
+    -DoutputDirectory=/tmp/
+mvn dependency:copy -B \
+    -Dartifact="com.oracle.ojdbc:ojdbc10:${ORACLE_VERSION}:jar" \
     -DoutputDirectory=/tmp/
 
 case ${DISTRO} in
@@ -70,6 +74,9 @@ module add --name=mysql.mysql-connector-java --slot=main --resources=/tmp/mysql-
 module add --name=org.postgresql.postgresql --slot=main --resources=/tmp/postgresql-${POSTGRESQL_VERSION}.jar --dependencies=javax.api,javax.transaction.api
 /subsystem=datasources/jdbc-driver=postgresql:add(driver-name="postgresql",driver-module-name="org.postgresql.postgresql",driver-xa-datasource-class-name=org.postgresql.xa.PGXADataSource)
 
+module add --name=com.oracle.ojdbc --slot=main --resources=/tmp/ojdbc10-${ORACLE_VERSION}.jar --dependencies=javax.api,javax.transaction.api
+/subsystem=datasources/jdbc-driver=oracle:add(driver-name="oracle",driver-module-name="com.oracle.ojdbc",driver-xa-datasource-class-name="oracle.jdbc.xa.client.OracleXADataSource")
+
 run-batch
 EOF
         /camunda/bin/jboss-cli.sh --file=batch.cli
@@ -78,6 +85,7 @@ EOF
     *)
         cp /tmp/mysql-connector-java-${MYSQL_VERSION}.jar /camunda/lib
         cp /tmp/postgresql-${POSTGRESQL_VERSION}.jar /camunda/lib
+        cp /tmp/ojdbc10-${ORACLE_VERSION}.jar /camunda/lib
         # remove default CATALINA_OPTS from environment settings
         echo "" > /camunda/bin/setenv.sh
         ;;


### PR DESCRIPTION
Ideally, need to add Oracle 19 to [database settings in platform](https://github.com/camunda/camunda-bpm-platform/blob/master/database/pom.xml).
And if you have access to [Oracle DB Docker Image](https://hub.docker.com/_/oracle-database-enterprise-edition), need to add tests compose with Oracle DB as like Postgres and MySQL.