### PR TITLE
compatibility with OpenShift, allow container running with an arbitry…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,9 @@ RUN apk add --no-cache \
     && chmod +x /usr/local/bin/wait-for-it.sh
 
 RUN addgroup -g 1000 -S camunda && \
-    adduser -u 1000 -S camunda -G camunda -h /camunda -s /bin/bash -D camunda
+    adduser -u 1000 -S camunda -G camunda -h /camunda -s /bin/bash -D camunda && \
+    adduser camunda root
+    
 WORKDIR /camunda
 USER camunda
 
@@ -72,3 +74,5 @@ ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["./camunda.sh"]
 
 COPY --chown=camunda:camunda --from=builder /camunda .
+RUN chgrp -R 0 /camunda
+RUN chmod -R g=u /camunda


### PR DESCRIPTION
Fixes #112 

Openshift run containers with a arbitry UID.
User is always in group 0.
This patch set /camunda with GID 0
