### PR TITLE
INFRA-822 - Run EE build only when CI is triggered by project maintainers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ script: |
         . &&
     ./test/test.sh &&
     ./release.sh
+if: env(NEXUS_USER) IS present AND env(NEXUS_PASS) IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,24 @@ language: generic
 sudo: required
 
 services:
-    - docker
+  - docker
 
 env:
-    - DISTRO=tomcat
-    - DISTRO=tomcat EE=true
-    - DISTRO=wildfly
-    - DISTRO=wildfly EE=true
+  - DISTRO=tomcat
+  - DISTRO=tomcat EE=true
+  - DISTRO=wildfly
+  - DISTRO=wildfly EE=true
 
-script: |
-    docker build -t camunda/camunda-bpm-platform:${DISTRO} \
-        --build-arg DISTRO=${DISTRO} \
-        --build-arg EE=${EE} \
-        --build-arg USER=${NEXUS_USER} \
-        --build-arg PASSWORD=${NEXUS_PASS} \
-        . &&
-    ./test/test.sh &&
-    ./release.sh
+script:
+  - |
+    docker build .                              \
+      -t camunda/camunda-bpm-platform:${DISTRO} \
+      --build-arg DISTRO=${DISTRO}              \
+      --build-arg EE=${EE}                      \
+      --build-arg USER=${NEXUS_USER}            \
+      --build-arg PASSWORD=${NEXUS_PASS}
+  - ./test/test.sh
+  - ./release.sh
+
+# Only build EE if Nexus credentials are provided (i.e. when CI is triggered by project maintainers not PRs).
 if: env(NEXUS_USER) IS present AND env(NEXUS_PASS) IS present


### PR DESCRIPTION
Travis removes encrypted secrets from pull-request builds.
Thus, the `EE=true` builds only work for PRs owned by project maintainers, not by forks.

So a condition added in Travis file to run EE build only when CI is triggered by project maintainers.

p.s. the build will fail for Tomcat, it's another issue and already reported to Camunda BPM team.