### PR TITLE
chore(travis): fix build config validation errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: generic
 
-sudo: required
+os: linux
 
 services:
   - docker


### PR DESCRIPTION
Travis reports that:
```
root: deprecated key sudo (The key `sudo` has no effect anymore.)
root: missing os, using the default linux
```

The `sudo` setting is now implicitly derived from the OS used as per https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system