### PR TITLE
Increase retry number to 20

### DIFF
--- a/test/test_helper.sh
+++ b/test/test_helper.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-RETRIES=12
+RETRIES=20
 WAIT=5
 function _log {
   >&2 echo $@


### PR DESCRIPTION
The wildfly server can take more than 60 seconds to come up.

This PR increases the number of retries before timing out the test