### PR TITLE
Upgrade to 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12 as builder
+FROM alpine:3.13 as builder
 
 ARG VERSION=7.16.0
 ARG DISTRO=tomcat
@@ -30,7 +30,7 @@ RUN /tmp/download.sh
 
 ##### FINAL IMAGE #####
 
-FROM alpine:3.12
+FROM alpine:3.13
 
 ARG VERSION=7.16.0
 


### PR DESCRIPTION
Upgrade to 3.13 to be able to use latest kerberos features like kstart package