### PR TITLE
Bind debug port to all interfaces in wildfly

### DIFF
--- a/camunda-wildfly.sh
+++ b/camunda-wildfly.sh
@@ -67,7 +67,7 @@ CMD="/camunda/bin/standalone.sh"
 
 if [ "${DEBUG}" = "true" ]; then
   echo "Enabling debug mode, JPDA accesible under port 8000"
-  CMD+=" --debug 8000"
+  CMD+=" --debug *:8000"
 fi
 
 if [ "$JMX_PROMETHEUS" = "true" ] ; then


### PR DESCRIPTION
This fix addresses #191 