### PR TITLE
fix(download.sh): change ee to virtual repo private with forced auth

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -3,7 +3,7 @@
 # Determine nexus URL parameters
 if [ "${EE}" = "true" ]; then
     echo "Downloading Camunda ${VERSION} Enterprise Edition for ${DISTRO}"
-    REPO="camunda-bpm-ee"
+    REPO="private"
     NEXUS_GROUP="private"
     ARTIFACT="camunda-bpm-ee-${DISTRO}"
     if [ "${DISTRO}" = "run" ]; then
@@ -20,7 +20,11 @@ fi
 
 # Determine if SNAPSHOT repo and version should be used
 if [ ${SNAPSHOT} = "true" ]; then
-    REPO="${REPO}-snapshots"
+    # CE artefacts are public, EE require forced authentication via virtual repository (private)
+    # preemptively sending them in settings.xml would fail CE builds
+    if [ "${EE}" = "false" ]; then
+        REPO="${REPO}-snapshots"
+    fi
     ARTIFACT_VERSION="${VERSION}-SNAPSHOT"
 fi
 


### PR DESCRIPTION
due to the migration to Artifactory, a minor adjustment in the repo is required.
We don't make use of preemptively sending the auth in the settings.xml as it would cause the ce builds to fail.

The change adjusts the repo to `private`, which is a virtual repo with forced auth and adjusted the snapshot behavior to not be `private-snapshot`

Tested with 7.17-snapshot, 7.17-ee-snapshot, 7.16, and 7.16-ee


I'll afterwards backport the change.