### PR TITLE
chore(.travis.yml): define ee env for pub builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ services:
   - docker
 
 env:
-  - DISTRO=tomcat
-  - DISTRO=wildfly
-  - DISTRO=run
+  - DISTRO=tomcat EE=false
+  - DISTRO=wildfly EE=false
+  - DISTRO=run EE=false
 
 jobs:
   include:  # do not run EE builds for forks (they don't have access to EE credentials)


### PR DESCRIPTION
otherwise overwritten by empty, which caused it to try to find snapshots in the release repo