### PR TITLE
CAM-14293: feat(run): use internal start script

### DIFF
--- a/camunda-run.sh
+++ b/camunda-run.sh
@@ -28,7 +28,7 @@ if [[ -z "${SPRING_DATASOURCE_URL:-}" && -n "${DB_URL:-}" ]]; then
   export SPRING_DATASOURCE_URL="${DB_URL}"
 fi
 
-CMD="/camunda/start.sh"
+CMD="/camunda/internal/run.sh start"
 
 if [ -n "${WAIT_FOR}" ]; then
   CMD="wait-for-it.sh ${WAIT_FOR} -s -t ${WAIT_FOR_TIMEOUT} -- ${CMD}"


### PR DESCRIPTION
Use `RUN_HOME/internal/run.sh start` to start Camunda Run. We changed the default behavior of `start.sh` to start Run in the background. Since a Docker container needs a foreground process (and log outputs), we need to use `run.sh`

Related to CAM-14293

:warning: Do not merge before https://github.com/camunda/camunda-bpm-platform/pull/1745 is merged.