### PR TITLE
CAM-14298: use correct db connection property on Tomcat

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ The used database can be configured by providing the following environment
 variables:
 
 - `DB_CONN_MAXACTIVE` the maximum number of active connections (default: `20`)
-  - for `tomcat`, this is internally mapped to the `maxTotal` configuration property.
 - `DB_CONN_MAXIDLE` the maximum number of idle connections (default: `20`)
   - ignored when app server = `wildfly` or `run`
 - `DB_CONN_MINIDLE` the minimum number of idle connections (default: `5`)

--- a/camunda-tomcat.sh
+++ b/camunda-tomcat.sh
@@ -22,7 +22,7 @@ XML_DRIVER="${XML_JDBC}/@driverClassName"
 XML_URL="${XML_JDBC}/@url"
 XML_USERNAME="${XML_JDBC}/@username"
 XML_PASSWORD="${XML_JDBC}/@password"
-XML_MAXTOTAL="${XML_JDBC}/@maxTotal"
+XML_MAXACTIVE="${XML_JDBC}/@maxActive"
 XML_MINIDLE="${XML_JDBC}/@minIdle"
 XML_MAXIDLE="${XML_JDBC}/@maxIdle"
 
@@ -33,7 +33,7 @@ if [ -z "$SKIP_DB_CONFIG" ]; then
     -u "${XML_URL}" -v "${DB_URL}" \
     -u "${XML_USERNAME}" -v "${DB_USERNAME}" \
     -u "${XML_PASSWORD}" -v "${DB_PASSWORD}" \
-    -u "${XML_MAXTOTAL}" -v "${DB_CONN_MAXACTIVE}" \
+    -u "${XML_MAXACTIVE}" -v "${DB_CONN_MAXACTIVE}" \
     -u "${XML_MINIDLE}" -v "${DB_CONN_MINIDLE}" \
     -u "${XML_MAXIDLE}" -v "${DB_CONN_MAXIDLE}" \
     -u "${XML_JDBC}/@testOnBorrow" -v "${DB_VALIDATE_ON_BORROW}" \


### PR DESCRIPTION
- when using the Tomcat JDBC connection pool, maxActive is the right
  configuration property, not maxTotal

related to CAM-14298