### PR TITLE
CAM-14470: chore(docker): expose debug port to all interfaces

### DIFF
--- a/camunda-wildfly.sh
+++ b/camunda-wildfly.sh
@@ -67,7 +67,7 @@ CMD="/camunda/bin/standalone.sh"
 
 if [ "${DEBUG}" = "true" ]; then
   echo "Enabling debug mode, JPDA accesible under port 8000"
-  CMD+=" --debug 8000"
+  CMD+=" --debug *:8000"
 fi
 
 if [ "$JMX_PROMETHEUS" = "true" ] ; then


### PR DESCRIPTION
* JDK 11 by default listens only on localhost when debug is enabled. In Wildfly, we need to expose the port on all interfaces so that Docker users can debug it remotely.

related to CAM-14470