### PR TITLE
Added data persistence for Tomcat

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -21,6 +21,9 @@ services:
             - mysql
         ports:
             - "8080:8080"
+        volumes:
+            - ./camunda-data/conf:/camunda/conf
+            - ./camunda-data/webapps:/camunda/webapps    
         restart: unless-stopped
 
     camunda-postgres:


### PR DESCRIPTION
## Description

This update aims to define default volumes to prevent any potential confusion or performance issues during the execution of a project with Camunda. By default, Tomcat will be used as the application server.

## Proposed Changes

- Definition of default volumes for different Camunda components
- Use of Tomcat as the default application server

## Benefits

- Increased clarity and ease of use for developers
- Avoid common issues related to the lack of volume configuration
- Improved performance of Camunda during project execution