### PR TITLE
Added data persistence for Tomcat version in docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,13 @@ docker run -d --name camunda -p 8080:8080 --link postgresql:db \
 Camunda Platform is installed inside the `/camunda` directory. Which
 means the Apache Tomcat configuration files are inside the `/camunda/conf/` 
 directory and the deployments on Apache Tomcat are in `/camunda/webapps/`. 
-The directory structure depends on the application server.
+The directory structure depends on the application server.  
+When using Tomcat, to make the data persistent, you can use the following code, just remember to create the folders camunda-data/conf and camunda-data/webapps:
+```
+volumes:
+    - ./camunda-data/conf:/camunda/conf
+    - ./camunda-data/webapps:/camunda/webapps
+```
 
 ### Debug
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -7,6 +7,9 @@ services:
         ports:
             - "8080:8080"
         restart: unless-stopped
+        volumes:
+            - ./camunda-data/conf:/camunda/conf
+            - ./camunda-data/webapps:/camunda/webapps
 
     camunda-mysql:
         image: camunda/camunda-bpm-platform:${DISTRO}-${PLATFORM}
@@ -21,6 +24,9 @@ services:
             - mysql
         ports:
             - "8080:8080"
+        volumes:
+            - ./camunda-data/conf:/camunda/conf
+            - ./camunda-data/webapps:/camunda/webapps
         restart: unless-stopped
 
     camunda-postgres:
@@ -36,6 +42,9 @@ services:
             - postgres
         ports:
             - "8080:8080"
+        volumes:
+            - ./camunda-data/conf:/camunda/conf
+            - ./camunda-data/webapps:/camunda/webapps
         restart: unless-stopped
 
     camunda-debug:
@@ -46,6 +55,9 @@ services:
         ports:
             - "8080:8080"
             - "8000:8000"
+        volumes:
+            - ./camunda-data/conf:/camunda/conf
+            - ./camunda-data/webapps:/camunda/webapps
         restart: unless-stopped
 
     camunda-prometheus-jmx:
@@ -56,6 +68,9 @@ services:
         ports:
             - "8080:8080"
             - "9404:9404"
+        volumes:
+            - ./camunda-data/conf:/camunda/conf
+            - ./camunda-data/webapps:/camunda/webapps
         restart: unless-stopped
 
     camunda-password-file:
@@ -73,6 +88,9 @@ services:
             - mysql
         ports:
             - "8080:8080"
+        volumes:
+            - ./camunda-data/conf:/camunda/conf
+            - ./camunda-data/webapps:/camunda/webapps
         restart: unless-stopped
 
     mysql:


### PR DESCRIPTION
I have made some changes to enable data persistence for the Tomcat version of the Camunda BPM Platform Docker repository. This pull request includes modifications to the docker-compose.yml file and updates to the README.md file to reflect the changes made.

Changes Made:
1. Modified the docker-compose.yml file to include a volume mount for data persistence in the Tomcat version.
2. Updated the README.md file to provide instructions on using the data persistence feature with the Tomcat version.

The addition of data persistence allows users to retain their data across container restarts, making it easier to maintain and manage long-term process instances and configurations. This enhancement improves the overall usability and reliability of the Camunda BPM Platform.

I have tested the changes locally using Docker Compose and verified that the data persistence feature works as expected with the Tomcat version of Camunda BPM Platform.

Thank you for your time and consideration.