### PR TITLE
wait-for-it / handle several databases if needed (primary/secondary/etc)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apk add --no-cache \
 COPY settings.xml download.sh camunda-run.sh camunda-tomcat.sh camunda-wildfly.sh  /tmp/
 
 RUN /tmp/download.sh
+COPY camunda-lib.sh /camunda/
 
 
 ##### FINAL IMAGE #####

--- a/README.md
+++ b/README.md
@@ -253,7 +253,10 @@ includes [wait-for-it.sh](https://github.com/vishnubob/wait-for-it) to allow the
 container to wait until a 'host:port' is ready. The mechanism can be configured 
 by two environment variables:
 
-- `WAIT_FOR`: the service `host:port` to wait for
+- `WAIT_FOR`: the service `host:port` to wait for. (In case of active/passive database setup,
+expecting to connect to the first available,
+you can also provide multiple host-port pairs separated by a comma or an empty space:
+(`"host1:port1 host2:port2"`)
 - `WAIT_FOR_TIMEOUT`: how long to wait for the service to be available in seconds
 
 Example with a PostgreSQL container:

--- a/camunda-lib.sh
+++ b/camunda-lib.sh
@@ -1,0 +1,18 @@
+wait_for_it() {
+  if [ -n "${WAIT_FOR}" ]; then
+    found=0
+    for host_port in $(echo "${WAIT_FOR}" | tr ',' '\n'); do
+      if wait-for-it.sh "$host_port" -s -t ${WAIT_FOR_TIMEOUT} ; then
+        echo "$host_port available"
+        found=1
+        break
+      else
+        echo "$host_port not available"
+      fi
+    done
+    if [ "$found" -eq 0 ] ; then
+      echo "No connection available in WAIT_FOR=$WAIT_FOR"
+      exit 1
+    fi
+  fi
+}

--- a/camunda-run.sh
+++ b/camunda-run.sh
@@ -3,6 +3,8 @@ set -Eeu
 
 trap 'Error on line $LINENO' ERR
 
+source $(dirname "$0")/camunda-lib.sh
+
 # Set Password as Docker Secrets for Swarm-Mode
 if [[ -z "${DB_PASSWORD:-}" && -n "${DB_PASSWORD_FILE:-}" && -f "${DB_PASSWORD_FILE:-}" ]]; then
   export DB_PASSWORD="$(< "${DB_PASSWORD_FILE}")"
@@ -30,9 +32,7 @@ fi
 
 CMD="/camunda/internal/run.sh start"
 
-if [ -n "${WAIT_FOR}" ]; then
-  CMD="wait-for-it.sh ${WAIT_FOR} -s -t ${WAIT_FOR_TIMEOUT} -- ${CMD}"
-fi
+wait_for_it
 
 # shellcheck disable=SC2086
 exec ${CMD} "$@"

--- a/camunda-tomcat.sh
+++ b/camunda-tomcat.sh
@@ -3,6 +3,8 @@ set -Eeu
 
 trap 'Error on line $LINENO' ERR
 
+source $(dirname "$0")/camunda-lib.sh
+
 # Use existing tomcat distribution if present..
 CATALINA_HOME="${CATALINA_HOME:-/camunda}"
 
@@ -58,9 +60,7 @@ fi
 
 CMD+=" run"
 
-if [ -n "${WAIT_FOR}" ]; then
-  CMD="wait-for-it.sh ${WAIT_FOR} -s -t ${WAIT_FOR_TIMEOUT} -- ${CMD}"
-fi
+wait_for_it
 
 # shellcheck disable=SC2086
 exec ${CMD}

--- a/camunda-wildfly.sh
+++ b/camunda-wildfly.sh
@@ -3,6 +3,8 @@ set -Eeu
 
 trap 'Error on line $LINENO' ERR
 
+source $(dirname "$0")/camunda-lib.sh
+
 # Set default values for DB_ variables
 # Set Password as Docker Secrets for Swarm-Mode
 if [[ -z "${DB_PASSWORD:-}" && -n "${DB_PASSWORD_FILE:-}" && -f "${DB_PASSWORD_FILE:-}" ]]; then
@@ -80,9 +82,7 @@ if [ "$JMX_PROMETHEUS" = "true" ] ; then
   export PREPEND_JAVA_OPTS="${PREPEND_JAVA_OPTS} -javaagent:/camunda/javaagent/jmx_prometheus_javaagent.jar=${JMX_PROMETHEUS_PORT}:${JMX_PROMETHEUS_CONF}"
 fi
 
-if [ -n "${WAIT_FOR}" ]; then
-  CMD="wait-for-it.sh ${WAIT_FOR} -s -t ${WAIT_FOR_TIMEOUT} -- ${CMD}"
-fi
+wait_for_it
 
 # shellcheck disable=SC2086
 exec ${CMD}


### PR DESCRIPTION
Fixes camunda/camunda-bpm-platform#3555

If you specify several database in your JDBC_URL, you might want to start if at latest on of them is responding.

https://github.com/camunda/camunda-bpm-platform/issues/3555



