### PR TITLE
chore(root): Adjust Supported JDK README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ disables Swagger UI by default.
 
 ### Java versions
 
-Our docker images are using the LTS OpenJDK version supported by
+Our docker images are using a LTS OpenJDK version supported by
 Camunda Platform. This currently means:
 
  - Camunda 7.20 or later will be based on OpenJDK 17.

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ disables Swagger UI by default.
 
 ### Java versions
 
-Our docker images are using the latest LTS OpenJDK version supported by
+Our docker images are using the LTS OpenJDK version supported by
 Camunda Platform. This currently means:
 
  - Camunda 7.20 or later will be based on OpenJDK 17.


### PR DESCRIPTION
- Adjust the README to reflect more accurately the JDK used by each version
- Latest JDK 21 is supported and 7.21 uses JDK 17

Related-to: https://github.com/camunda/camunda-bpm-platform/issues/4002