### PR TITLE
chore(test): migrate to docker compose v2 CLI syntax

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -6,12 +6,12 @@ cd ${DIR}
 
 source test_helper.sh
 
-docker-compose up --force-recreate -d postgres mysql
+docker compose up --force-recreate -d postgres mysql
 ./test-${DISTRO}.sh camunda
 ./test-${DISTRO}.sh camunda-mysql
 ./test-${DISTRO}.sh camunda-postgres
 ./test-${DISTRO}.sh camunda-password-file
 ./test-prometheus-jmx-${DISTRO}.sh camunda-prometheus-jmx
 ./test-debug.sh camunda-debug
-docker-compose down -v
+docker compose down -v
 cd -

--- a/test/test_helper.sh
+++ b/test/test_helper.sh
@@ -2,20 +2,14 @@
 RETRIES=100
 WAIT=5
 
-GHA=${GITHUB_ACTIONS:-false}
-if [ "${GHA}" = "true" ]; then
-  shopt -s expand_aliases
-  alias docker-compose="docker compose"
-fi
-
 function _log {
   >&2 echo $@
 }
 
 function stop_container {
   docker logs $(container_id)
-  docker-compose kill ${SERVICE}
-  docker-compose rm --force ${SERVICE}
+  docker compose kill ${SERVICE}
+  docker compose rm --force ${SERVICE}
 }
 
 function _exit {
@@ -25,11 +19,11 @@ function _exit {
 }
 
 function start_container {
-  docker-compose up -d --no-recreate ${SERVICE} || _exit 1 "Unable to start compose"
+  docker compose up -d --no-recreate ${SERVICE} || _exit 1 "Unable to start compose"
 }
 
 function container_id {
-  docker-compose ps -q ${SERVICE}
+  docker compose ps -q ${SERVICE}
 }
 
 function grep_log {


### PR DESCRIPTION
Relate to https://github.com/camunda/team-infrastructure/issues/953.

Migrate to docker compose v2 CLI syntax: `docker-compose` -> `docker compose`

Tests: 
- Failing job with 7.24 branch: 7.24/job/7.24-platform-docker-ee](https://dev.ci.cambpm.camunda.cloud/view/all/job/7.24/job/7.24-platform-docker-ee/1/)
- Working job with this branch: [7.24/job/7.24-platform-docker-ee](https://dev.ci.cambpm.camunda.cloud/view/all/job/7.24/job/7.24-platform-docker-ee/7/console)
    -  additional checks for [7.23](https://stage.ci.cambpm.camunda.cloud/view/all/job/7.23/job/7.23-platform-docker-ee/2/console) and [7.16](https://stage.ci.cambpm.camunda.cloud/view/all/job/7.16/job/7.16-platform-docker-ee/3/console) on `stage`

<img width="1357" height="531" alt="image" src="https://github.com/user-attachments/assets/adad56b0-da2f-445e-bdfb-25677f2074f0" />
