### PR TITLE
[Backport 7.20] chore(test): migrate to docker compose v2 CLI syntax

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -6,12 +6,12 @@ cd ${DIR}
 
 source test_helper.sh
 
-docker-compose up --force-recreate -d postgres mysql
+docker compose up --force-recreate -d postgres mysql
 ./test-${DISTRO}.sh camunda
 ./test-${DISTRO}.sh camunda-mysql
 ./test-${DISTRO}.sh camunda-postgres
 ./test-${DISTRO}.sh camunda-password-file
 ./test-prometheus-jmx-${DISTRO}.sh camunda-prometheus-jmx
 ./test-debug.sh camunda-debug
-docker-compose down -v
+docker compose down -v
 cd -

--- a/test/test_helper.sh
+++ b/test/test_helper.sh
@@ -2,20 +2,14 @@
 RETRIES=100
 WAIT=5
 
-GHA=${GITHUB_ACTIONS:-false}
-if [ "${GHA}" = "true" ]; then
-  shopt -s expand_aliases
-  alias docker-compose="docker compose"
-fi
-
 function _log {
   >&2 echo $@
 }
 
 function stop_container {
   docker logs $(container_id)
-  docker-compose kill ${SERVICE}
-  docker-compose rm --force ${SERVICE}
+  docker compose kill ${SERVICE}
+  docker compose rm --force ${SERVICE}
 }
 
 function _exit {
@@ -25,11 +19,11 @@ function _exit {
 }
 
 function start_container {
-  docker-compose up -d --no-recreate ${SERVICE} || _exit 1 "Unable to start compose"
+  docker compose up -d --no-recreate ${SERVICE} || _exit 1 "Unable to start compose"
 }
 
 function container_id {
-  docker-compose ps -q ${SERVICE}
+  docker compose ps -q ${SERVICE}
 }
 
 function grep_log {


### PR DESCRIPTION
Backport of #323 to 7.20 branch.

Relate to https://github.com/camunda/team-infrastructure/issues/953.

Migrate to docker compose v2 CLI syntax: `docker-compose` -> `docker compose`