### PR TITLE
[Backport 7.18] chore(test): migrate to docker compose v2 CLI syntax

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -3,12 +3,12 @@
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 cd ${DIR}
-docker-compose up --force-recreate -d postgres mysql
+docker compose up --force-recreate -d postgres mysql
 ./test-${DISTRO}.sh camunda
 ./test-${DISTRO}.sh camunda-mysql
 ./test-${DISTRO}.sh camunda-postgres
 ./test-${DISTRO}.sh camunda-password-file
 ./test-prometheus-jmx-${DISTRO}.sh camunda-prometheus-jmx
 ./test-debug.sh camunda-debug
-docker-compose down -v
+docker compose down -v
 cd -

--- a/test/test_helper.sh
+++ b/test/test_helper.sh
@@ -7,8 +7,8 @@ function _log {
 
 function stop_container {
   docker logs $(container_id)
-  docker-compose kill ${SERVICE}
-  docker-compose rm --force ${SERVICE}
+  docker compose kill ${SERVICE}
+  docker compose rm --force ${SERVICE}
 }
 
 function _exit {
@@ -18,11 +18,11 @@ function _exit {
 }
 
 function start_container {
-  docker-compose up -d --no-recreate ${SERVICE} || _exit 1 "Unable to start compose"
+  docker compose up -d --no-recreate ${SERVICE} || _exit 1 "Unable to start compose"
 }
 
 function container_id {
-  docker-compose ps -q ${SERVICE}
+  docker compose ps -q ${SERVICE}
 }
 
 function grep_log {


### PR DESCRIPTION
Backport of #323 to 7.18 branch.

Relate to https://github.com/camunda/team-infrastructure/issues/953.

Migrate to docker compose v2 CLI syntax: `docker-compose` -> `docker compose`

**Note:** Conflicts were resolved during cherry-pick (minor differences in test.sh structure).