### PR TITLE
fix: migrate Nexus vault keys to Terraform-managed credentials

### DIFF
--- a/.github/workflows/build-and-test-ee.yml
+++ b/.github/workflows/build-and-test-ee.yml
@@ -31,8 +31,8 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           exportEnv: false
           secrets: |
-            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_USR | NEXUS_USER;
-            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_PSW | NEXUS_PASS;
+            secret/data/products/cambpm/ci/nexus USER | NEXUS_USER;
+            secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_PASS;
             secret/data/products/cambpm/ci/harbor username | HARBOR_USERNAME;
             secret/data/products/cambpm/ci/harbor password | HARBOR_PASSWORD;
       - name: Login to Harbor

--- a/.github/workflows/build-test-and-publish-ce.yml
+++ b/.github/workflows/build-test-and-publish-ce.yml
@@ -21,8 +21,8 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           exportEnv: false
           secrets: |
-            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_USR | NEXUS_USER;
-            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_PSW | NEXUS_PASS;
+            secret/data/products/cambpm/ci/nexus USER | NEXUS_USER;
+            secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_PASS;
             secret/data/products/cambpm/ci/harbor username | HARBOR_USERNAME;
             secret/data/products/cambpm/ci/harbor password | HARBOR_PASSWORD;
       - name: Login to Harbor
@@ -66,8 +66,8 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           exportEnv: false
           secrets: |
-            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_USR | NEXUS_USER;
-            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_PSW | NEXUS_PASS;
+            secret/data/products/cambpm/ci/nexus USER | NEXUS_USER;
+            secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_PASS;
             secret/data/products/cambpm/ci/harbor username | HARBOR_USERNAME;
             secret/data/products/cambpm/ci/harbor password | HARBOR_PASSWORD;
       - name: Login to Harbor


### PR DESCRIPTION
## What

Update `vault-action` secrets blocks to read the new Terraform-managed key names (`USER`/`PASSWORD`) from `secret/products/cambpm/ci/nexus`, using aliases to preserve existing output variable names (`NEXUS_USER`/`NEXUS_PASS`).

## Why

The Vault secret at `secret/products/cambpm/ci/nexus` was migrated to Terraform-managed credentials (camunda/infra-core#12687), which replaced the legacy `NEXUS_APP_CAMUNDA_COM_USR`/`NEXUS_APP_CAMUNDA_COM_PSW` keys with standardized `USER`/`PASSWORD` keys.

These workflows currently read the old key names which will be removed once all consumers are migrated.

## Changes

- `build-and-test-ee.yml`: Updated vault secrets to read `USER | NEXUS_USER` and `PASSWORD | NEXUS_PASS`
- `build-test-and-publish-ce.yml`: Updated 2 vault secrets blocks (build-and-test, build-and-test-arm)

No downstream changes needed — `settings.xml`, `pipeline.sh`, and `Dockerfile` already use the aliased names.

related to camunda/team-infrastructure#1033