### PR TITLE
chore(alpine): upgrade base docker image to alpine 3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22 as builder
+FROM alpine:3.23 as builder
 
 ARG VERSION=7.23.0
 ARG DISTRO=tomcat
@@ -34,7 +34,7 @@ COPY camunda-lib.sh /camunda/
 
 ##### FINAL IMAGE #####
 
-FROM alpine:3.22
+FROM alpine:3.23
 
 ARG VERSION=7.23.0
 


### PR DESCRIPTION
chore(alpine): upgrade base docker image to alpine 3.23
- upgrade base docker image to alpine 3.23 

Related to: https://github.com/camunda/camunda-bpm-platform-maintenance/issues/2954